### PR TITLE
fix: no alert & can't start cloze after changing text

### DIFF
--- a/app/worker.js
+++ b/app/worker.js
@@ -340,6 +340,7 @@ function sendText(do_jump=true, removeDup=remove_dup){
 	demo.scrollIntoView()
 	demo.style.backgroundImage="url(\"" + baseServer + "/text-faces/?article="+encodeURIComponent(s)+"&redundantList="+encodeURIComponent(encodeURIComponent(JSON.stringify(redundantList)))+"__large.png\")"
 	refreshChangeable()
+    state_in_excise = false
     }
     var words = allWords(s)
     var wordsValid=ruleAllWords(words, ruleArray, getSimpleFilter())


### PR DESCRIPTION
Reproduce:
click Cloze -> change text -> click Start -> click Cloze

It seems that the flag suggesting test state should be turned to false in a jump init.